### PR TITLE
Adds the option to register the ICookieService as a singleton in WASM apps.

### DIFF
--- a/src/BitzArt.Blazor.Cookies.Client/Extensions/AddBlazorCookiesExtension.cs
+++ b/src/BitzArt.Blazor.Cookies.Client/Extensions/AddBlazorCookiesExtension.cs
@@ -10,4 +10,10 @@ public static class AddBlazorCookiesExtension
         builder.Services.AddScoped<ICookieService, BrowserCookieService>();
         return builder;
     }
+
+    public static WebAssemblyHostBuilder AddBlazorCookiesSingleton(this WebAssemblyHostBuilder builder)
+    {
+        builder.Services.AddSingleton<ICookieService, BrowserCookieService>();
+        return builder;
+    }
 }


### PR DESCRIPTION
Sometimes, you just want a singleton in your service container instead. Should function exactly the same.