### PR TITLE
Generic cookies

### DIFF
--- a/src/BitzArt.Blazor.Cookies.Server/Services/HttpContextCookieService.cs
+++ b/src/BitzArt.Blazor.Cookies.Server/Services/HttpContextCookieService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 namespace BitzArt.Blazor.Cookies.Server;
 
@@ -38,6 +39,15 @@ internal class HttpContextCookieService : ICookieService
         if (_requestCookies.TryGetValue(key, out var cookie)) return Task.FromResult<Cookie?>(cookie);
 
         return Task.FromResult<Cookie?>(null);
+    }
+
+    public Task<Cookie<T>?> GetAsync<T>(string key, JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        if (_requestCookies.TryGetValue(key, out var cookie))
+        {
+            return Task.FromResult<Cookie<T>?>(cookie.Cast<T>(jsonSerializerOptions));
+        }
+        return Task.FromResult<Cookie<T>?>(null);
     }
 
     // ========================================  SetAsync  ========================================

--- a/src/BitzArt.Blazor.Cookies/Attributes/FromCookieAttribute.cs
+++ b/src/BitzArt.Blazor.Cookies/Attributes/FromCookieAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace BitzArt.Blazor.Cookies;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+internal class FromCookieAttribute : Attribute
+{
+}

--- a/src/BitzArt.Blazor.Cookies/Attributes/FromCookieAttribute.cs
+++ b/src/BitzArt.Blazor.Cookies/Attributes/FromCookieAttribute.cs
@@ -1,6 +1,0 @@
-﻿namespace BitzArt.Blazor.Cookies;
-
-[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-internal class FromCookieAttribute : Attribute
-{
-}

--- a/src/BitzArt.Blazor.Cookies/Interfaces/ICookieService.cs
+++ b/src/BitzArt.Blazor.Cookies/Interfaces/ICookieService.cs
@@ -18,7 +18,7 @@ public interface ICookieService
     /// </summary>
     public Task<IEnumerable<Cookie>> GetAllAsync();
 
-    /// <inheritdoc cref="GetAsync{T}(string)"/>
+    /// <inheritdoc cref="GetAsync{T}(string,JsonSerializerOptions)"/>
     public Task<Cookie?> GetAsync(string key);
 
     /// <summary>

--- a/src/BitzArt.Blazor.Cookies/Interfaces/ICookieService.cs
+++ b/src/BitzArt.Blazor.Cookies/Interfaces/ICookieService.cs
@@ -1,4 +1,6 @@
-﻿namespace BitzArt.Blazor.Cookies;
+﻿using System.Text.Json;
+
+namespace BitzArt.Blazor.Cookies;
 
 /// <summary>
 /// Allows interacting with browser cookies.
@@ -16,6 +18,9 @@ public interface ICookieService
     /// </summary>
     public Task<IEnumerable<Cookie>> GetAllAsync();
 
+    /// <inheritdoc cref="GetAsync{T}(string)"/>
+    public Task<Cookie?> GetAsync(string key);
+
     /// <summary>
     /// Retrieves a cookie by its key.
     /// <para>
@@ -25,9 +30,11 @@ public interface ICookieService
     /// (such as `HttpOnly`, `Secure`, and `SameSite`) hidden for security and privacy reasons.
     /// </para>
     /// </summary>
-    /// <param name="key"> The key of the cookie to retrieve. </param>
-    /// <returns> The requested cookie, or null if it does not exist. </returns>
-    public Task<Cookie?> GetAsync(string key);
+    /// <param name="key"> Key of the cookie to retrieve. </param>
+    /// <param name="jsonSerializerOptions"> JSON serializer options to use when deserializing cookie value. </param>
+    /// <returns> The requested cookie, or null if it was not found. </returns>
+    /// <typeparam name="T"> Type of the cookie value. </typeparam>
+    public Task<Cookie<T>?> GetAsync<T>(string key, JsonSerializerOptions? jsonSerializerOptions = null);
 
     /// <summary>
     /// Removes a cookie by marking it as expired.

--- a/src/BitzArt.Blazor.Cookies/Models/Cookie.cs
+++ b/src/BitzArt.Blazor.Cookies/Models/Cookie.cs
@@ -1,4 +1,92 @@
-﻿namespace BitzArt.Blazor.Cookies;
+﻿using System.Text.Json;
+
+namespace BitzArt.Blazor.Cookies;
+
+/// <inheritdoc cref="Cookie{T}"/>
+public class Cookie
+{
+    private protected string _value;
+
+    /// <summary>
+    /// Name of the cookie.
+    /// </summary>
+    public string Key { get; set; }
+
+    /// <summary>
+    /// Value of the cookie.
+    /// </summary>
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            _value = value;
+            OnValueChanged(value);
+        }
+    }
+
+    /// <summary>
+    /// Cookie expiration date.
+    /// </summary>
+    public DateTimeOffset? Expiration { get; set; }
+
+    /// <summary>
+    /// Whether the cookie is inaccessible by client-side script.
+    /// </summary>
+    public bool HttpOnly { get; set; }
+
+    /// <summary>
+    /// Whether to transmit the cookie using Secure Sockets Layer (SSL)--that is, over HTTPS only.
+    /// </summary>
+    public bool Secure { get; set; }
+
+    /// <summary>
+    /// <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value">SameSiteMode</see>
+    /// controls whether or not a cookie is sent with cross-site requests, providing some protection against cross-site request forgery attacks
+    /// (<see href="https://developer.mozilla.org/en-US/docs/Glossary/CSRF">CSRF</see>). <br />
+    /// <b>Note:</b> Null value will result in the browser using it's default behavior.
+    /// </summary>
+    public SameSiteMode? SameSiteMode { get; set; }
+
+    /// <summary>
+    /// Creates a new <see cref="Cookie"/>.
+    /// </summary>
+    /// <param name="key"> Name of the cookie. </param>
+    /// <param name="value"> Value of the cookie. </param>
+    /// <param name="expiration"> Cookie expiration date. </param>
+    /// <param name="httpOnly"> Whether the cookie is inaccessible by client-side script. </param>
+    /// <param name="secure"> Whether to transmit the cookie using Secure Sockets Layer (SSL)--that is, over HTTPS only. </param>
+    /// <param name="sameSiteMode">
+    /// <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value">SameSiteMode</see>
+    /// controls whether or not a cookie is sent with cross-site requests, providing some protection against cross-site request forgery attacks
+    /// (<see href="https://developer.mozilla.org/en-US/docs/Glossary/CSRF">CSRF</see>). <br />
+    /// <b>Note:</b> Null value will result in the browser using it's default behavior.
+    /// </param>
+    public Cookie(string key, string value, DateTimeOffset? expiration = null, bool httpOnly = false, bool secure = false, SameSiteMode? sameSiteMode = null)
+    {
+        Key = key;
+        _value = value;
+        Expiration = expiration;
+        HttpOnly = httpOnly;
+        Secure = secure;
+        SameSiteMode = sameSiteMode;
+    }
+
+    private protected virtual void OnValueChanged(string value) { }
+
+    /// <inheritdoc cref="Cookie(string, string, DateTimeOffset?, bool, bool, SameSiteMode?)"/>
+    public static Cookie<T> FromValue<T>(string key, T value, DateTimeOffset? expiration = null, bool httpOnly = false, bool secure = false, SameSiteMode? sameSiteMode = null, JsonSerializerOptions jsonSerializerOptions = null)
+        => new(key, value, expiration, httpOnly, secure, sameSiteMode, jsonSerializerOptions);
+
+    /// <summary>
+    /// Casts a <see cref="Cookie"/> to a <see cref="Cookie{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">Target type of the cookie value.</typeparam>
+    /// <param name="jsonSerializerOptions">JSON serializer options to use when deserializing the value.</param>
+    /// <returns><see cref="Cookie{T}"/>, where T: <typeparamref name="T"/>.</returns>
+    public Cookie<T> Cast<T>(JsonSerializerOptions? jsonSerializerOptions = null)
+        => new(Key, JsonSerializer.Deserialize<T>(Value, jsonSerializerOptions ?? new())!, Expiration, HttpOnly, Secure, SameSiteMode, jsonSerializerOptions);
+}
 
 /// <summary>
 /// Browser cookie.
@@ -9,15 +97,39 @@
 /// (such as `HttpOnly`, `Secure`, and `SameSite`) hidden for security and privacy reasons.
 /// </para>
 /// </summary>
-/// <param name="Key"> The name of the cookie. </param>
-/// <param name="Value"> The value of the cookie. </param>
-/// <param name="Expiration"> The expiration date of the cookie. </param>
-/// <param name="HttpOnly"> Whether the cookie is inaccessible by client-side script. </param>
-/// <param name="Secure"> Whether to transmit the cookie using Secure Sockets Layer (SSL)--that is, over HTTPS only. </param>
-/// <param name="SameSiteMode">
-/// <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value">SameSiteMode</see>
-/// controls whether or not a cookie is sent with cross-site requests, providing some protection against cross-site request forgery attacks
-/// (<see href="https://developer.mozilla.org/en-US/docs/Glossary/CSRF">CSRF</see>). <br />
-/// <b>Note:</b> Null value will result in the browser using it's default behavior.
-/// </param>
-public record Cookie(string Key, string Value, DateTimeOffset? Expiration = null, bool HttpOnly = false, bool Secure = false, SameSiteMode? SameSiteMode = null);
+/// <typeparam name="T"> Type of the cookie value. </typeparam>
+public class Cookie<T> : Cookie
+{
+    private T? _value;
+
+    /// <summary>
+    /// The value of the cookie.
+    /// </summary>
+    public new T? Value
+    {
+        get => _value;
+        set
+        {
+            _value = value;
+            base._value = JsonSerializer.Serialize(value, JsonSerializerOptions);
+        }
+    }
+
+    private protected override void OnValueChanged(string value)
+    {
+        _value = JsonSerializer.Deserialize<T>(base.Value, JsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// JSON serialization options to use when serializing/deserializing the cookie value.
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions { get; set; } = new();
+
+    /// <inheritdoc cref="Cookie(string, string, DateTimeOffset?, bool, bool, SameSiteMode?)"/>/>
+    public Cookie(string key, T value, DateTimeOffset? expiration = null, bool httpOnly = false, bool secure = false, SameSiteMode? sameSiteMode = null, JsonSerializerOptions? jsonSerializerOptions = null)
+        : base(key, JsonSerializer.Serialize(value, jsonSerializerOptions ?? new()), expiration, httpOnly, secure, sameSiteMode)
+    {
+        _value = value;
+        JsonSerializerOptions = jsonSerializerOptions ?? new();
+    }
+}

--- a/src/BitzArt.Blazor.Cookies/Models/Cookie.cs
+++ b/src/BitzArt.Blazor.Cookies/Models/Cookie.cs
@@ -75,7 +75,7 @@ public class Cookie
     private protected virtual void OnValueChanged(string value) { }
 
     /// <inheritdoc cref="Cookie(string, string, DateTimeOffset?, bool, bool, SameSiteMode?)"/>
-    public static Cookie<T> FromValue<T>(string key, T value, DateTimeOffset? expiration = null, bool httpOnly = false, bool secure = false, SameSiteMode? sameSiteMode = null, JsonSerializerOptions jsonSerializerOptions = null)
+    public static Cookie<T> FromValue<T>(string key, T value, DateTimeOffset? expiration = null, bool httpOnly = false, bool secure = false, SameSiteMode? sameSiteMode = null, JsonSerializerOptions? jsonSerializerOptions = null)
         => new(key, value, expiration, httpOnly, secure, sameSiteMode, jsonSerializerOptions);
 
     /// <summary>
@@ -100,7 +100,7 @@ public class Cookie
 /// <typeparam name="T"> Type of the cookie value. </typeparam>
 public class Cookie<T> : Cookie
 {
-    private T? _value;
+    private protected new T? _value;
 
     /// <summary>
     /// The value of the cookie.

--- a/src/BitzArt.Blazor.Cookies/Services/JsInteropCookieService.cs
+++ b/src/BitzArt.Blazor.Cookies/Services/JsInteropCookieService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.JSInterop;
+using System.Text.Json;
 
 namespace BitzArt.Blazor.Cookies;
 
@@ -19,13 +20,20 @@ internal class JsInteropCookieService(IJSRuntime js) : ICookieService
     private Cookie GetCookie(string raw)
     {
         var parts = raw.Split("=", 2);
-        return new Cookie(parts[0], parts[1], null, HttpOnly: false, Secure: false);
+        return new Cookie(parts[0], parts[1], null, httpOnly: false, secure: false);
     }
 
     public async Task<Cookie?> GetAsync(string key)
     {
         var cookies = await GetAllAsync();
         return cookies.FirstOrDefault(x => x.Key == key);
+    }
+
+    public async Task<Cookie<T>?> GetAsync<T>(string key, JsonSerializerOptions? jsonSerializerOptions = null)
+    {
+        var cookie = await GetAsync(key);
+        if (cookie is null) return null;
+        return cookie.Cast<T>(jsonSerializerOptions);
     }
 
     // ========================================  SetAsync  ========================================

--- a/tests/BitzArt.Blazor.Cookies.Tests/SerializedCookieTests.cs
+++ b/tests/BitzArt.Blazor.Cookies.Tests/SerializedCookieTests.cs
@@ -59,7 +59,7 @@ public class SerializedCookieTests
         var newValueSerialized = JsonSerializer.Serialize(newValue);
 
         // Act
-        (cookie as Cookie).Value = JsonSerializer.Serialize(newValue);
+        (cookie as Cookie).Value = newValueSerialized;
 
         // Assert
         Assert.NotEqual(initialValue, newValue);

--- a/tests/BitzArt.Blazor.Cookies.Tests/SerializedCookieTests.cs
+++ b/tests/BitzArt.Blazor.Cookies.Tests/SerializedCookieTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Text.Json;
+
+namespace BitzArt.Blazor.Cookies;
+
+public class SerializedCookieTests
+{
+    [Fact]
+    public void Ctor_WithValue_ShouldSaveAndSerializeValue()
+    {
+        // Arrange
+        var value = new { a = "a" };
+
+        // Act
+        var cookie = Cookie.FromValue("test-cookie", value);
+
+        // Assert
+        Assert.Equal("test-cookie", cookie.Key);
+
+        var expectedStringValue = JsonSerializer.Serialize(value);
+        var stringValue = (cookie as Cookie).Value;
+
+        Assert.Equal(expectedStringValue, stringValue);
+    }
+
+    [Fact]
+    public void ValueSet_WithValue_ShouldSaveAndSerializeValue()
+    {
+        // Arrange
+        var initialValue = new TestPayload("initial value");
+        var cookie = Cookie.FromValue("test-cookie", initialValue);
+
+        // Act
+        var newValue = new TestPayload("new value");
+        cookie.Value = newValue;
+
+        // Assert
+        Assert.NotEqual(initialValue, newValue);
+
+        Assert.NotEqual(initialValue, cookie.Value);
+        Assert.Equal(newValue, cookie.Value);
+
+        var initialStringValue = JsonSerializer.Serialize(initialValue);
+        var expectedStringValue = JsonSerializer.Serialize(newValue);
+
+        var stringValue = (cookie as Cookie).Value;
+
+        Assert.NotEqual(initialStringValue, stringValue);
+        Assert.Equal(expectedStringValue, stringValue);
+    }
+
+    [Fact]
+    public void ValueSet_OnBaseValueProperty_ShouldDeserializeToDescendantValue()
+    {
+        // Arrange
+        var initialValue = new TestPayload("initial value");
+        var cookie = Cookie.FromValue("test-cookie", initialValue);
+
+        var newValue = new TestPayload("new value");
+        var newValueSerialized = JsonSerializer.Serialize(newValue);
+
+        // Act
+        (cookie as Cookie).Value = JsonSerializer.Serialize(newValue);
+
+        // Assert
+        Assert.NotEqual(initialValue, newValue);
+
+        Assert.NotEqual(initialValue, cookie.Value);
+        Assert.Equal(newValue.Data, cookie.Value!.Data);
+    }
+
+    private class TestPayload(string data)
+    {
+        public string Data { get; set; } = data;
+    }
+}


### PR DESCRIPTION
Allows setting and retrieving generic cookies, automatically serializing and deserializing their respective values as needed. E.g.

```csharp
public class MyClass
{
    public int MyValue { get; set; }
}

// new Cookie<T> class usage examples
public void ExampleCookieUsage()
{
    var data = new MyClass
    {
        MyValue = 1
    };

    var cookie = Cookie.FromValue("key", data);
    // or
    var cookie = new Cookie<MyClass>("key", data);
    // or
    var stringValue = JsonSerializer.Serialize(data);
    var cookie = new Cookie("key", stringValue).Cast<MyData>();

    // this cookie can then be persisted using ICookieService
}

// New method allows for automatic value deserialization when retrieving a cookie
public void ExampleServiceUsage(ICookieService cookieService)
{
    Cookie<MyData> myCookie = cookieService.Get<MyData>("key");
}
```